### PR TITLE
ci(workflow-actions): update checkout version and bump config

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -12,19 +12,18 @@ jobs:
     name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
+          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          body_path: "body.md"
-          tag_name: ${{ env.REVISION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.REVISION }}
+          bodyFile: "body.md"
+          skipIfReleaseExists: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
@@ -38,7 +38,7 @@ jobs:
     needs: deploy
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,8 @@
+## 0.2.0 (2024-08-03)
+
+### Fix
+
+- **bandit**: add selector for running bandit command
+- **.pre-commit-config.yaml-&-default-test-file**: include all tests when running pytest for pre-commits
+
 ## 0.1.0 (2024-07-28)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "boilersetup"
-version = "0.1.0"
+version = "0.2.0"
 description = "Template Boilerplate Setup for Python projects"
 authors = ["Stephen Singer <stephen.singer.098@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Update all GitHub workflow actions to use checkout version 4 to remove warning on action run. Additionally, update the bump config to use the same setup configured by `commitizen`.

BREAKING CHANGE: Changes GitHub Action Workflow versions and configurations