### PR TITLE
ci: update github workflow actions and change mkdocs deployment implementation

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,7 +18,7 @@ jobs:
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  lint_format:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -20,17 +20,70 @@ jobs:
           pip install poetry
           poetry install
 
-      - name: Lint and format
+      - name: Lint code
+        run: poetry run ruff check .
+
+      - name: Check formatting
         run: |
-          poetry run ruff check .
           poetry run black --check .
           poetry run isort --check-only .
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint_format
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
 
       - name: Run tests
         run: poetry run pytest
 
+  type_check:
+    runs-on: ubuntu-latest
+    needs: lint_format
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
+
       - name: Type check
         run: poetry run pyright
+
+  security_check:
+    runs-on: ubuntu-latest
+    needs: lint_format
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
 
       - name: Security check
         run: poetry run bandit -c bandit.yaml .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,11 @@ jobs:
       - name: Build documentation
         run: poetry run mkdocs build
 
-      - name: Deploy documentation
-        env:
-          GH_PAT: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        run: |
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
-          poetry run mkdocs gh-deploy --force --remote-name origin --remote-branch gh-pages --message "Deploy docs" --token $PERSONAL_ACCESS_TOKEN
+      - name: Push doc to Github Page
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./site
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
- Update all `actions/setup-python@v4` calls to actions/setup-python@v5
- Separate steps in `.github/workflows/check.yml` into jobs for modularity.
- Use the pre-configured `peaceiris/actions-gh-pages@v4` in `.github/workflows/release.yml` to automatically configure docs publishing for `mkdocs` after build.