### PR TITLE
ci(workflow-check): combine jobs into multi-step for efficiency

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,101 +1,50 @@
-name: Check
+name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
-  lint_format:
+  build:
+    runs-on: ubuntu-latest
+
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-    runs-on: ubuntu-latest
+        python-version: [3.9, 3.10, 3.11, 3.12]
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
-          pip install poetry
-          poetry install
-
-      - name: Lint code
-        run: poetry run ruff check .
-
-      - name: Check formatting
-        run: |
-          poetry run black --check .
-          poetry run isort --check-only .
-
-  test:
-    needs: lint_format
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
+          python -m pip install --upgrade pip
           pip install poetry
           poetry install
 
       - name: Run tests
         run: poetry run pytest
 
-  type_check:
-    needs: [lint_format, test]
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - name: Lint code
+        run: poetry run ruff .
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Format code
+        run: poetry run black --check .
 
-      - name: Install dependencies
-        run: |
-          pip install poetry
-          poetry install
+      - name: Sort imports
+        run: poetry run isort --check-only .
 
       - name: Type check
         run: poetry run pyright
 
-  security_check:
-    needs: [lint_format, test, type_check]
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          pip install poetry
-          poetry install
-
       - name: Security check
-        run: poetry run bandit -c bandit.yaml .
+        run: poetry run bandit -r .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,15 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.0 (2024-08-03)
+
+### BREAKING CHANGE
+
+- Updated packaages to latest versions
+
 ## 0.7.0 (2024-08-03)
 
 ### BREAKING CHANGE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "boilersetup"
-version = "0.7.0"
+version = "0.8.0"
 description = "Template Boilerplate Setup for Python projects"
 authors = ["Stephen Singer <stephen.singer.098@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Revert the refactoring of `.github/workflows/check.yml` by combining the jobs into multiple steps instead to ensure a single GitHub action on tests